### PR TITLE
sshInterfaceId for primary and secondary device in self configured devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 *.dll
 *.so
 *.dylib
+.idea
+*.iml
 
 # Test binary, built with `go test -c`
 *.test

--- a/client.go
+++ b/client.go
@@ -251,6 +251,7 @@ type Device struct {
 	InterfaceCount      *int
 	CoreCount           *int
 	IsSelfManaged       *bool
+	WanInterfaceId      *string
 	Interfaces          []DeviceInterface
 	VendorConfiguration map[string]string
 	UserPublicKey       *DeviceUserPublicKey

--- a/internal/api/device.go
+++ b/internal/api/device.go
@@ -32,6 +32,7 @@ type Device struct {
 	InterfaceCount       *int                   `json:"interfaceCount,omitempty"`
 	Core                 *DeviceCoreInformation `json:"core,omitempty"`
 	DeviceManagementType *string                `json:"deviceManagementType,omitempty"`
+	SshInterfaceId       *string                `json:"sshInterfaceId,omitempty"`
 	Interfaces           []DeviceInterface      `json:"interfaces,omitempty"`
 	VendorConfig         map[string]string      `json:"vendorConfig,omitempty"`
 	UserPublicKey        *DeviceUserPublicKey   `json:"userPublicKey,omitempty"`

--- a/internal/api/device.go
+++ b/internal/api/device.go
@@ -59,6 +59,7 @@ type DeviceRequest struct {
 	Version              *string                     `json:"version,omitempty"`
 	InterfaceCount       *int                        `json:"interfaceCount,omitempty"`
 	DeviceManagementType *string                     `json:"deviceManagementType,omitempty"`
+	SshInterfaceId       *string                     `json:"sshInterfaceId,omitempty"`
 	Core                 *int                        `json:"core,omitempty"`
 	AdditionalBandwidth  *int                        `json:"additionalBandwidth,omitempty,string"`
 	ACLTemplateUUID      *string                     `json:"aclTemplateUuid,omitempty"`
@@ -77,6 +78,7 @@ type SecondaryDeviceRequest struct {
 	HostNamePrefix      *string                     `json:"hostNamePrefix,omitempty"`
 	AccountNumber       *string                     `json:"accountNumber,omitempty"`
 	AdditionalBandwidth *int                        `json:"additionalBandwidth,omitempty,string"`
+	SshInterfaceId      *string                     `json:"sshInterfaceId,omitempty"`
 	ACLTemplateUUID     *string                     `json:"aclTemplateUuid,omitempty"`
 	VendorConfig        map[string]string           `json:"vendorConfig,omitempty"`
 	UserPublicKey       *DeviceUserPublicKeyRequest `json:"userPublicKey,omitempty"`

--- a/rest_device.go
+++ b/rest_device.go
@@ -207,6 +207,7 @@ func mapDeviceAPIToDomain(apiDevice api.Device) *Device {
 	device.RedundantUUID = apiDevice.RedundantUUID
 	device.TermLength = apiDevice.TermLength
 	device.AdditionalBandwidth = apiDevice.AdditionalBandwidth
+	device.WanInterfaceId = apiDevice.SshInterfaceId
 	device.OrderReference = apiDevice.OrderReference
 	device.InterfaceCount = apiDevice.InterfaceCount
 	if apiDevice.Core != nil {

--- a/rest_device.go
+++ b/rest_device.go
@@ -295,6 +295,7 @@ func createDeviceRequest(device Device) api.DeviceRequest {
 	if device.IsSelfManaged != nil {
 		if *device.IsSelfManaged {
 			req.DeviceManagementType = String(DeviceManagementTypeSelf)
+			req.SshInterfaceId = device.WanInterfaceId
 		} else {
 			req.DeviceManagementType = String(DeviceManagementTypeEquinix)
 		}
@@ -318,6 +319,10 @@ func createRedundantDeviceRequest(primary Device, secondary Device) api.DeviceRe
 	secReq.HostNamePrefix = secondary.HostName
 	secReq.AccountNumber = secondary.AccountNumber
 	secReq.AdditionalBandwidth = secondary.AdditionalBandwidth
+	secReq.SshInterfaceId = secondary.WanInterfaceId
+	if secReq.SshInterfaceId == nil {
+		secReq.SshInterfaceId = req.SshInterfaceId
+	}
 	secReq.ACLTemplateUUID = secondary.ACLTemplateUUID
 	secReq.VendorConfig = secondary.VendorConfiguration
 	secReq.UserPublicKey = mapDeviceUserPublicKeyDomainToAPI(secondary.UserPublicKey)

--- a/rest_device.go
+++ b/rest_device.go
@@ -296,13 +296,13 @@ func createDeviceRequest(device Device) api.DeviceRequest {
 	if device.IsSelfManaged != nil {
 		if *device.IsSelfManaged {
 			req.DeviceManagementType = String(DeviceManagementTypeSelf)
-			req.SshInterfaceId = device.WanInterfaceId
 		} else {
 			req.DeviceManagementType = String(DeviceManagementTypeEquinix)
 		}
 	}
 	req.Core = device.CoreCount
 	req.AdditionalBandwidth = device.AdditionalBandwidth
+	req.SshInterfaceId = device.WanInterfaceId
 	req.ACLTemplateUUID = device.ACLTemplateUUID
 	req.VendorConfig = device.VendorConfiguration
 	req.UserPublicKey = mapDeviceUserPublicKeyDomainToAPI(device.UserPublicKey)


### PR DESCRIPTION
Add sshInterfaceId for both primary and secondary device in self configured scenario when creating devices

Needed for https://github.com/equinix/terraform-provider-equinix/pull/58