### PR TITLE
NFV-18043: modify cluster fields and add mgmt acl in existing device API

### DIFF
--- a/client.go
+++ b/client.go
@@ -428,24 +428,18 @@ type DeviceLinkGroupLink struct {
 
 //ClusterDetails describes Network Edge cluster device details
 type ClusterDetails struct {
-	ClusterName        *string
-	NumOfNodes         *int
-	ClusterNodeDetails map[string]*ClusterNodeDetail
-	ClusterId          *string
-	Nodes              []ClusterNode
+	ClusterId   *string
+	ClusterName *string
+	NumOfNodes  *int
+	Node0       *ClusterNodeDetail
+	Node1       *ClusterNodeDetail
 }
 
-//ClusterNodeDetail describes Network Edge cluster node configuration
+//ClusterNodeDetail describes Network Edge cluster node details
 type ClusterNodeDetail struct {
+	UUID                *string
+	Name                *string
 	VendorConfiguration map[string]string
 	LicenseFileId       *string
 	LicenseToken        *string
-}
-
-type ClusterNode struct {
-	UUID                *string
-	Name                *string
-	Node                *int
-	AdminPassword       *string
-	VendorConfiguration map[string]string
 }

--- a/client.go
+++ b/client.go
@@ -428,11 +428,13 @@ type DeviceLinkGroupLink struct {
 
 //ClusterDetails describes Network Edge cluster device details
 type ClusterDetails struct {
-	ClusterId   *string
-	ClusterName *string
-	NumOfNodes  *int
-	Node0       *ClusterNodeDetail
-	Node1       *ClusterNodeDetail
+	ClusterName        *string
+	NumOfNodes         *int
+	ClusterNodeDetails map[string]*ClusterNodeDetail // Deprecated: Use Node0 and Node1 instead
+	ClusterId          *string
+	Nodes              []ClusterNode // Deprecated: Use Node0 and Node1 instead
+	Node0              *ClusterNodeDetail
+	Node1              *ClusterNodeDetail
 }
 
 //ClusterNodeDetail describes Network Edge cluster node details
@@ -442,4 +444,12 @@ type ClusterNodeDetail struct {
 	VendorConfiguration map[string]string
 	LicenseFileId       *string
 	LicenseToken        *string
+}
+
+type ClusterNode struct { // Deprecated: Use ClusterNodeDetail instead
+	UUID                *string
+	Name                *string
+	Node                *int
+	AdminPassword       *string
+	VendorConfiguration map[string]string
 }

--- a/internal/api/device.go
+++ b/internal/api/device.go
@@ -170,7 +170,6 @@ type DeviceACLResponse struct {
 //ClusterDetailsRequest describes cluster details of device creation request
 type ClusterDetailsRequest struct {
 	ClusterName        *string                             `json:"clusterName,omitempty"`
-	NumOfNodes         *int                                `json:"numOfNodes,omitempty"`
 	ClusterNodeDetails map[string]ClusterNodeDetailRequest `json:"clusterNodeDetails,omitempty"`
 }
 

--- a/internal/api/device.go
+++ b/internal/api/device.go
@@ -85,6 +85,7 @@ type SecondaryDeviceRequest struct {
 	AdditionalBandwidth *int                        `json:"additionalBandwidth,omitempty,string"`
 	SshInterfaceId      *string                     `json:"sshInterfaceId,omitempty"`
 	ACLTemplateUUID     *string                     `json:"aclTemplateUuid,omitempty"`
+	MgmtAclTemplateUuid *string                     `json:"mgmtAclTemplateUuid,omitempty"`
 	VendorConfig        map[string]string           `json:"vendorConfig,omitempty"`
 	UserPublicKey       *DeviceUserPublicKeyRequest `json:"userPublicKey,omitempty"`
 }

--- a/rest_device.go
+++ b/rest_device.go
@@ -287,17 +287,16 @@ func mapDeviceClusterDetailsAPIToDomain(apiClusterDetails *api.ClusterDetails) *
 	clusterDetails.ClusterName = apiClusterDetails.ClusterName
 	clusterDetails.NumOfNodes = apiClusterDetails.NumOfNodes
 	apiNodes := apiClusterDetails.Nodes
-	transformed := make([]ClusterNode, len(apiNodes))
+	transformed := make([]*ClusterNodeDetail, len(apiNodes))
 	for i := range apiNodes {
-		transformed[i] = ClusterNode{
+		transformed[i] = &ClusterNodeDetail{
 			UUID:                apiNodes[i].UUID,
 			Name:                apiNodes[i].Name,
-			Node:                apiNodes[i].Node,
-			AdminPassword:       apiNodes[i].AdminPassword,
 			VendorConfiguration: apiNodes[i].VendorConfiguration,
 		}
 	}
-	clusterDetails.Nodes = transformed
+	clusterDetails.Node0 = transformed[0]
+	clusterDetails.Node1 = transformed[1]
 	return &clusterDetails
 }
 
@@ -307,11 +306,9 @@ func mapDeviceClusterDetailsDomainToAPI(clusterDetails *ClusterDetails) *api.Clu
 	}
 	req := api.ClusterDetailsRequest{}
 	req.ClusterName = clusterDetails.ClusterName
-	req.NumOfNodes = clusterDetails.NumOfNodes
 	clusterNodeDetailsRequest := make(map[string]api.ClusterNodeDetailRequest)
-	for k, v := range clusterDetails.ClusterNodeDetails {
-		clusterNodeDetailsRequest[k] = *mapDeviceClusterNodeDetailDomainToAPI(v)
-	}
+	clusterNodeDetailsRequest["node0"] = *mapDeviceClusterNodeDetailDomainToAPI(clusterDetails.Node0)
+	clusterNodeDetailsRequest["node1"] = *mapDeviceClusterNodeDetailDomainToAPI(clusterDetails.Node1)
 	req.ClusterNodeDetails = clusterNodeDetailsRequest
 	return &req
 }

--- a/rest_device.go
+++ b/rest_device.go
@@ -389,6 +389,7 @@ func createRedundantDeviceRequest(primary Device, secondary Device) api.DeviceRe
 		secReq.SshInterfaceId = req.SshInterfaceId
 	}
 	secReq.ACLTemplateUUID = secondary.ACLTemplateUUID
+	secReq.MgmtAclTemplateUuid = secondary.MgmtAclTemplateUuid
 	secReq.VendorConfig = secondary.VendorConfiguration
 	secReq.UserPublicKey = mapDeviceUserPublicKeyDomainToAPI(secondary.UserPublicKey)
 	req.Secondary = &secReq

--- a/rest_device.go
+++ b/rest_device.go
@@ -287,16 +287,25 @@ func mapDeviceClusterDetailsAPIToDomain(apiClusterDetails *api.ClusterDetails) *
 	clusterDetails.ClusterName = apiClusterDetails.ClusterName
 	clusterDetails.NumOfNodes = apiClusterDetails.NumOfNodes
 	apiNodes := apiClusterDetails.Nodes
-	transformed := make([]*ClusterNodeDetail, len(apiNodes))
+	transformed := make([]ClusterNode, len(apiNodes))
+	clusterNodeDetails := make([]*ClusterNodeDetail, len(apiNodes))
 	for i := range apiNodes {
-		transformed[i] = &ClusterNodeDetail{
+		transformed[i] = ClusterNode{
+			UUID:                apiNodes[i].UUID,
+			Name:                apiNodes[i].Name,
+			Node:                apiNodes[i].Node,
+			AdminPassword:       apiNodes[i].AdminPassword,
+			VendorConfiguration: apiNodes[i].VendorConfiguration,
+		}
+		clusterNodeDetails[i] = &ClusterNodeDetail{
 			UUID:                apiNodes[i].UUID,
 			Name:                apiNodes[i].Name,
 			VendorConfiguration: apiNodes[i].VendorConfiguration,
 		}
 	}
-	clusterDetails.Node0 = transformed[0]
-	clusterDetails.Node1 = transformed[1]
+	clusterDetails.Nodes = transformed
+	clusterDetails.Node0 = clusterNodeDetails[0]
+	clusterDetails.Node1 = clusterNodeDetails[1]
 	return &clusterDetails
 }
 
@@ -307,6 +316,9 @@ func mapDeviceClusterDetailsDomainToAPI(clusterDetails *ClusterDetails) *api.Clu
 	req := api.ClusterDetailsRequest{}
 	req.ClusterName = clusterDetails.ClusterName
 	clusterNodeDetailsRequest := make(map[string]api.ClusterNodeDetailRequest)
+	for k, v := range clusterDetails.ClusterNodeDetails {
+		clusterNodeDetailsRequest[k] = *mapDeviceClusterNodeDetailDomainToAPI(v)
+	}
 	clusterNodeDetailsRequest["node0"] = *mapDeviceClusterNodeDetailDomainToAPI(clusterDetails.Node0)
 	clusterNodeDetailsRequest["node1"] = *mapDeviceClusterNodeDetailDomainToAPI(clusterDetails.Node1)
 	req.ClusterNodeDetails = clusterNodeDetailsRequest

--- a/rest_device.go
+++ b/rest_device.go
@@ -316,9 +316,6 @@ func mapDeviceClusterDetailsDomainToAPI(clusterDetails *ClusterDetails) *api.Clu
 	req := api.ClusterDetailsRequest{}
 	req.ClusterName = clusterDetails.ClusterName
 	clusterNodeDetailsRequest := make(map[string]api.ClusterNodeDetailRequest)
-	for k, v := range clusterDetails.ClusterNodeDetails {
-		clusterNodeDetailsRequest[k] = *mapDeviceClusterNodeDetailDomainToAPI(v)
-	}
 	clusterNodeDetailsRequest["node0"] = *mapDeviceClusterNodeDetailDomainToAPI(clusterDetails.Node0)
 	clusterNodeDetailsRequest["node1"] = *mapDeviceClusterNodeDetailDomainToAPI(clusterDetails.Node1)
 	req.ClusterNodeDetails = clusterNodeDetailsRequest

--- a/rest_device_test.go
+++ b/rest_device_test.go
@@ -95,6 +95,7 @@ func TestCreateRedundantDevice(t *testing.T) {
 		AccountNumber:       String("99999"),
 		AdditionalBandwidth: Int(200),
 		ACLTemplateUUID:     String("4972e8d2-417f-4821-91a8-f4a61a6dcdc3"),
+		MgmtAclTemplateUuid: String("4972e8d2-417f-4821-91a8-f4a61a6dcdc3"),
 		VendorConfiguration: map[string]string{
 			"serialNumber": "2222222",
 			"controller1":  "2.2.2.2",
@@ -478,6 +479,7 @@ func verifyRedundantDeviceRequest(t *testing.T, primary, secondary Device, req a
 	assert.Equal(t, secondary.AccountNumber, req.Secondary.AccountNumber, "Secondary AccountNumber matches")
 	assert.Equal(t, secondary.AdditionalBandwidth, req.Secondary.AdditionalBandwidth, "Secondary AdditionalBandwidth matches")
 	assert.Equal(t, secondary.ACLTemplateUUID, req.Secondary.ACLTemplateUUID, "Secondary ACLTemplateUUID matches")
+	assert.Equal(t, secondary.MgmtAclTemplateUuid, req.Secondary.MgmtAclTemplateUuid, "Secondary MgmtAclTemplateUuid matches")
 	assert.Equal(t, secondary.VendorConfiguration, req.Secondary.VendorConfig, "Secondary VendorConfigurations match")
 	assert.NotNil(t, req.Secondary.UserPublicKey, "UserPublicKey is not nil")
 	verifyDeviceUserPublicKeyRequest(t, *secondary.UserPublicKey, *req.Secondary.UserPublicKey)

--- a/rest_device_test.go
+++ b/rest_device_test.go
@@ -156,21 +156,19 @@ func TestCreateClusterDevice(t *testing.T) {
 		},
 		ClusterDetails: &ClusterDetails{
 			ClusterName: String("clusterName"),
-			ClusterNodeDetails: map[string]*ClusterNodeDetail{
-				"node0": {
-					VendorConfiguration: map[string]string{
-						"hostName": "panw-host0",
-					},
-					LicenseFileId: String("8d180057-8309-4c59-b645-f630f010ad43"),
-					LicenseToken:  String("licenseToken"),
+			Node0: &ClusterNodeDetail{
+				VendorConfiguration: map[string]string{
+					"hostname": "panw-host0",
 				},
-				"node1": {
-					VendorConfiguration: map[string]string{
-						"hostName": "panw-host1",
-					},
-					LicenseFileId: String("8d180057-8309-4c59-b645-f630f010ad43"),
-					LicenseToken:  String("licenseToken"),
+				LicenseFileId: String("8d180057-8309-4c59-b645-f630f010ad43"),
+				LicenseToken:  String("licenseToken"),
+			},
+			Node1: &ClusterNodeDetail{
+				VendorConfiguration: map[string]string{
+					"hostname": "panw-host1",
 				},
+				LicenseFileId: String("8d180057-8309-4c59-b645-f630f010ad43"),
+				LicenseToken:  String("licenseToken"),
 			},
 		},
 	}
@@ -530,9 +528,8 @@ func verifyClusterDetailsRequest(t *testing.T, clusterDetails ClusterDetails, ap
 	assert.Equal(t, clusterDetails.ClusterName, apiClusterDetailsReq.ClusterName, "ClusterName matches")
 	apiClusterNodeDetailReqMap := apiClusterDetailsReq.ClusterNodeDetails
 	assert.NotNil(t, apiClusterNodeDetailReqMap, "ClusterNodeDetails are not nil")
-	for k, v := range clusterDetails.ClusterNodeDetails {
-		verifyClusterNodeDetailRequest(t, v, apiClusterNodeDetailReqMap[k])
-	}
+	verifyClusterNodeDetailRequest(t, clusterDetails.Node0, apiClusterNodeDetailReqMap["node0"])
+	verifyClusterNodeDetailRequest(t, clusterDetails.Node1, apiClusterNodeDetailReqMap["node1"])
 }
 
 func verifyClusterNodeDetailRequest(t *testing.T, clusterNodeDetail *ClusterNodeDetail, apiClusterNodeDetailReq api.ClusterNodeDetailRequest) {


### PR DESCRIPTION
This PR changes the format of `ClusterDetails` and `ClusterNodeDetail`. `ClusterNode` is no longer needed in `client.go` because we will introduce `Node0` and `Node1` in `ClusterDetails` while also removing the previous container of these fields, `ClusterNodeDetails`.

This simplifies the structures and keeps `client.go` consistent with the Terraform changes being introduced in https://github.com/equinix/terraform-provider-equinix/pull/105.