### PR TITLE
NFV-18603: add mgmtAclTemplateUuid in the device acl update request

### DIFF
--- a/client.go
+++ b/client.go
@@ -141,6 +141,7 @@ type DeviceUpdateRequest interface {
 	WithNotifications(notifications []string) DeviceUpdateRequest
 	WithAdditionalBandwidth(additionalBandwidth int) DeviceUpdateRequest
 	WithACLTemplate(templateID string) DeviceUpdateRequest
+	WithMgmtAclTemplate(mgmtAclTemplateUuid string) DeviceUpdateRequest
 	Execute() error
 }
 

--- a/internal/api/device.go
+++ b/internal/api/device.go
@@ -153,8 +153,8 @@ type DevicesResponse struct {
 
 //DeviceACLTemplateRequest describes request for updating device ACL template
 type DeviceACLTemplateRequest struct {
-	TemplateUUID        *string `json:"aclTemplateUuid"`
-	MgmtAclTemplateUuid *string `json:"mgmtAclTemplateUuid"`
+	TemplateUUID        *string `json:"aclTemplateUuid,omitempty"`
+	MgmtAclTemplateUuid *string `json:"mgmtAclTemplateUuid,omitempty"`
 }
 
 //DeviceAdditionalBandwidthResponse describes response for device additional

--- a/internal/api/device.go
+++ b/internal/api/device.go
@@ -153,7 +153,8 @@ type DevicesResponse struct {
 
 //DeviceACLTemplateRequest describes request for updating device ACL template
 type DeviceACLTemplateRequest struct {
-	TemplateUUID *string `json:"aclTemplateUuid"`
+	TemplateUUID        *string `json:"aclTemplateUuid"`
+	MgmtAclTemplateUuid *string `json:"mgmtAclTemplateUuid"`
 }
 
 //DeviceAdditionalBandwidthResponse describes response for device additional

--- a/rest_device.go
+++ b/rest_device.go
@@ -416,12 +416,9 @@ func createRedundantDeviceRequest(primary Device, secondary Device) api.DeviceRe
 
 func (c RestClient) replaceDeviceACLTemplate(uuid string, wanAclTemplateUuid *string, mgmtAclTemplateUuid *string) error {
 	path := "/ne/v1/devices/" + url.PathEscape(uuid) + "/acl"
-	reqBody := api.DeviceACLTemplateRequest{}
-	if wanAclTemplateUuid != nil {
-		reqBody.TemplateUUID = wanAclTemplateUuid
-	}
-	if mgmtAclTemplateUuid != nil {
-		reqBody.MgmtAclTemplateUuid = mgmtAclTemplateUuid
+	reqBody := api.DeviceACLTemplateRequest{
+		TemplateUUID:        wanAclTemplateUuid,
+		MgmtAclTemplateUuid: mgmtAclTemplateUuid,
 	}
 	req := c.R().SetBody(reqBody)
 	if err := c.Execute(req, http.MethodPost, path); err != nil {


### PR DESCRIPTION
As part of NE April release, we want to add mgmt acl in the device creation flow as well as device acl update flow. The mgmt acl field was introduced in Feb release in our NE API.  Some vendors (e.g. Cisco FTD, PANW and Nginx) support that field.

More details could be found at the following link.
https://developer.equinix.com/docs/acl-template#get-acl-virtual-device
https://developer.equinix.com/docs/acl-template#update-acl-virtual-device

The given link shows the new API contract for acl and mgmt acl. However, the changes in this PR still use the original contract which looks like the following payload.
endpoint: POST /v1​/devices​/{virtualDeviceUUID}​/acl
request body:
```device acl update payload
{
  "aclTemplateUuid": "string",
  "mgmtAclTemplateUuid": "string"
}
```