### PR TITLE
Adds a generic Go test action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,25 @@
+name: Go
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.17
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v ./...


### PR DESCRIPTION
We have tests in ne-go that are not being tested in PRs today.  This PR will address that by adding testing to the CI/CD pipeline.

This action was recommended in the GitHub action marketplace. This is a reasonable starting point.