### PR TITLE
NFV-19565: add description field for the acl template inbound rule

### DIFF
--- a/client.go
+++ b/client.go
@@ -365,14 +365,15 @@ type ACLTemplate struct {
 //ACLTemplateInboundRule describes inbound ACL rule that is part of
 //Network Edge device ACL template
 type ACLTemplateInboundRule struct {
-	SeqNo    *int
-	FQDN     *string  // Deprecated: FQDN is no longer supported
-	SrcType  *string  // Deprecated: SrcType is not required.
-	Subnets  []string // Deprecated: Use subnet instead.
-	Subnet   *string
-	Protocol *string
-	SrcPort  *string
-	DstPort  *string
+	SeqNo       *int
+	FQDN        *string  // Deprecated: FQDN is no longer supported
+	SrcType     *string  // Deprecated: SrcType is not required.
+	Subnets     []string // Deprecated: Use subnet instead.
+	Subnet      *string
+	Protocol    *string
+	SrcPort     *string
+	DstPort     *string
+	Description *string
 }
 
 //ACLTemplateDeviceDetails describes Device Details this template applied to

--- a/internal/api/acltemplate.go
+++ b/internal/api/acltemplate.go
@@ -15,13 +15,14 @@ type ACLTemplate struct {
 //ACLTemplateInboundRule describes inbound ACL rule that is part of
 //Network Edge device ACL template
 type ACLTemplateInboundRule struct {
-	SrcType  *string  `json:"srcType,omitempty"`
-	Protocol *string  `json:"protocol,omitempty"`
-	SrcPort  *string  `json:"srcPort,omitempty"`
-	DstPort  *string  `json:"dstPort,omitempty"`
-	Subnets  []string `json:"subnets,omitempty"`
-	Subnet   *string  `json:"subnet,omitempty"`
-	SeqNO    *int     `json:"seqNo,omitempty"`
+	SrcType     *string  `json:"srcType,omitempty"`
+	Protocol    *string  `json:"protocol,omitempty"`
+	SrcPort     *string  `json:"srcPort,omitempty"`
+	DstPort     *string  `json:"dstPort,omitempty"`
+	Subnets     []string `json:"subnets,omitempty"`
+	Subnet      *string  `json:"subnet,omitempty"`
+	SeqNO       *int     `json:"seqNo,omitempty"`
+	Description *string  `json:"description,omitempty"`
 }
 
 type ACLTemplateDeviceDetails struct {

--- a/rest_acltemplate.go
+++ b/rest_acltemplate.go
@@ -100,13 +100,14 @@ func mapACLTemplateInboundRulesDomainToAPI(rules []ACLTemplateInboundRule) []api
 
 func mapACLTemplateInboundRuleDomainToAPI(rule ACLTemplateInboundRule) api.ACLTemplateInboundRule {
 	return api.ACLTemplateInboundRule{
-		SrcType:  rule.SrcType,
-		Protocol: rule.Protocol,
-		SrcPort:  rule.SrcPort,
-		DstPort:  rule.DstPort,
-		Subnet:   rule.Subnet,
-		Subnets:  rule.Subnets,
-		SeqNO:    rule.SeqNo,
+		SrcType:     rule.SrcType,
+		Protocol:    rule.Protocol,
+		SrcPort:     rule.SrcPort,
+		DstPort:     rule.DstPort,
+		Subnet:      rule.Subnet,
+		Subnets:     rule.Subnets,
+		SeqNO:       rule.SeqNo,
+		Description: rule.Description,
 	}
 }
 
@@ -132,13 +133,14 @@ func mapACLTemplateInboundRulesAPIToDomain(apiRules []api.ACLTemplateInboundRule
 
 func mapACLTemplateInboundRuleAPIToDomain(apiRule api.ACLTemplateInboundRule) ACLTemplateInboundRule {
 	return ACLTemplateInboundRule{
-		SrcType:  apiRule.SrcType,
-		Protocol: apiRule.Protocol,
-		SrcPort:  apiRule.SrcPort,
-		DstPort:  apiRule.DstPort,
-		Subnets:  apiRule.Subnets,
-		Subnet:   apiRule.Subnet,
-		SeqNo:    apiRule.SeqNO,
+		SrcType:     apiRule.SrcType,
+		Protocol:    apiRule.Protocol,
+		SrcPort:     apiRule.SrcPort,
+		DstPort:     apiRule.DstPort,
+		Subnets:     apiRule.Subnets,
+		Subnet:      apiRule.Subnet,
+		SeqNo:       apiRule.SeqNO,
+		Description: apiRule.Description,
 	}
 }
 

--- a/rest_acltemplate_test.go
+++ b/rest_acltemplate_test.go
@@ -18,12 +18,13 @@ var testACLTemplate = ACLTemplate{
 	MetroCode:   String("SV"),
 	InboundRules: []ACLTemplateInboundRule{
 		{
-			SrcType:  String("SUBNET"),
-			SeqNo:    Int(1),
-			Subnets:  []string{"10.0.0.0/24"},
-			Protocol: String("TCP"),
-			SrcPort:  String("any"),
-			DstPort:  String("22"),
+			SrcType:     String("SUBNET"),
+			SeqNo:       Int(1),
+			Subnets:     []string{"10.0.0.0/24"},
+			Protocol:    String("TCP"),
+			SrcPort:     String("any"),
+			DstPort:     String("22"),
+			Description: String("Description of the rule"),
 		},
 		{
 			SrcType:  String("DOMAIN"),
@@ -174,12 +175,13 @@ func verifyACLTemplate(t *testing.T, template ACLTemplate, apiTemplate api.ACLTe
 }
 
 func verifyACLTemplateInboundRule(t *testing.T, rule ACLTemplateInboundRule, apiRule api.ACLTemplateInboundRule) {
-	assert.Equal(t, rule.SeqNo, rule.SeqNo, "SeqNo matches")
-	assert.Equal(t, rule.SrcType, rule.SrcType, "SrcType matches")
-	assert.ElementsMatch(t, rule.Subnets, rule.Subnets, "Subnets matches")
-	assert.Equal(t, rule.Protocol, rule.Protocol, "Protocol matches")
-	assert.Equal(t, rule.SrcPort, rule.SrcPort, "SrcPort matches")
-	assert.Equal(t, rule.DstPort, rule.DstPort, "DstPort matches")
+	assert.Equal(t, rule.SeqNo, apiRule.SeqNO, "SeqNo matches")
+	assert.Equal(t, rule.SrcType, apiRule.SrcType, "SrcType matches")
+	assert.ElementsMatch(t, rule.Subnets, apiRule.Subnets, "Subnets matches")
+	assert.Equal(t, rule.Protocol, apiRule.Protocol, "Protocol matches")
+	assert.Equal(t, rule.SrcPort, apiRule.SrcPort, "SrcPort matches")
+	assert.Equal(t, rule.DstPort, apiRule.DstPort, "DstPort matches")
+	assert.Equal(t, rule.Description, apiRule.Description, "Description matches")
 }
 
 func verifyACLTemplateDeviceDetails(t *testing.T, template ACLTemplate, apiTemplate api.ACLTemplate) {
@@ -188,6 +190,5 @@ func verifyACLTemplateDeviceDetails(t *testing.T, template ACLTemplate, apiTempl
 		assert.Equal(t, template.DeviceDetails[i].UUID, apiTemplate.DeviceDetails[i].UUID, "UUID matches")
 		assert.Equal(t, template.DeviceDetails[i].Name, apiTemplate.DeviceDetails[i].Name, "Name matches")
 		assert.Equal(t, template.DeviceDetails[i].ACLStatus, apiTemplate.DeviceDetails[i].ACLStatus, "ACL Status matches")
-
 	}
 }

--- a/test-fixtures/ne_acltemplate_get_resp.json
+++ b/test-fixtures/ne_acltemplate_get_resp.json
@@ -10,7 +10,8 @@
             ],
             "protocol": "TCP",
             "srcPort": "any",
-            "dstPort": "22"
+            "dstPort": "22",
+            "description": "Description of the rule"
         },
         {
             "srcType": "DOMAIN",

--- a/test-fixtures/ne_acltemplates_get_resp.json
+++ b/test-fixtures/ne_acltemplates_get_resp.json
@@ -19,7 +19,8 @@
                     ],
                     "protocol": "IP",
                     "srcPort": "any",
-                    "dstPort": "any"
+                    "dstPort": "any",
+                    "description": "Description of the rule"
                 }
             ],
             "metroName": "Sydney",


### PR DESCRIPTION
As part of August release, we add a description field for each inbound rule of acl template. We want to add that field as part of terraform script as well.
This description field will always be optional and the field length should not be longer than 200 characters. 
It will be part of create/update request. It will also be part of get response.
Sample payload as follows:
```
  "inboundRules": [
        {
            "description": "description of the rule",
            "protocol": "TCP",
            "srcPort": "any",
            "dstPort": "any",
            "subnet": "216.221.225.13/32",
            "seqNo": 1
        },
        {
            "protocol": "TCP",
            "srcPort": "53",
            "dstPort": "any",
            "subnet": "1.1.1.1/32",
            "seqNo": 2
        }
  ]
```