### PR TITLE
NFV-22886: add cloudInitFileId field for device creation request and introduce new file upload API

### DIFF
--- a/client.go
+++ b/client.go
@@ -126,6 +126,7 @@ type Client interface {
 	DeleteACLTemplate(uuid string) error
 
 	UploadLicenseFile(metroCode, deviceTypeCode, deviceManagementMode, licenseMode, fileName string, reader io.Reader) (*string, error)
+	UploadFile(metroCode, deviceTypeCode, processType, deviceManagementMode, licenseMode, fileName string, reader io.Reader) (*string, error)
 
 	GetDeviceLinkGroups() ([]DeviceLinkGroup, error)
 	GetDeviceLinkGroup(uuid string) (*DeviceLinkGroup, error)
@@ -244,7 +245,9 @@ type Device struct {
 	IsBYOL              *bool
 	LicenseToken        *string
 	LicenseFile         *string
+	CloudInitFile       *string
 	LicenseFileID       *string
+	CloudInitFileID     *string
 	ACLTemplateUUID     *string
 	MgmtAclTemplateUuid *string
 	SSHIPAddress        *string

--- a/internal/api/device.go
+++ b/internal/api/device.go
@@ -18,6 +18,7 @@ type Device struct {
 	LicenseToken         *string                `json:"licenseToken,omitempty"`
 	LicenseType          *string                `json:"licenseType,omitempty"`
 	LicenseFileID        *string                `json:"licenseFileId,omitempty"`
+	CloudInitFileID      *string                `json:"CloudInitFileId,omitempty"`
 	ACLTemplateUUID      *string                `json:"aclTemplateUuid,omitempty"`
 	MgmtAclTemplateUUID  *string                `json:"mgmtAclTemplateUuid,omitempty"`
 	SSHIPAddress         *string                `json:"sshIpAddress,omitempty"`
@@ -52,6 +53,7 @@ type DeviceRequest struct {
 	LicenseMode          *string                     `json:"licenseMode,omitempty"`
 	LicenseToken         *string                     `json:"licenseToken,omitempty"`
 	LicenseFileID        *string                     `json:"licenseFileId,omitempty"`
+	CloudInitFileID      *string                     `json:"cloudInitFileId,omitempty"`
 	PackageCode          *string                     `json:"packageCode,omitempty"`
 	VirtualDeviceName    *string                     `json:"virtualDeviceName,omitempty"`
 	Notifications        []string                    `json:"notifications,omitempty"`
@@ -78,6 +80,7 @@ type SecondaryDeviceRequest struct {
 	MetroCode           *string                     `json:"metroCode,omitempty"`
 	LicenseToken        *string                     `json:"licenseToken,omitempty"`
 	LicenseFileID       *string                     `json:"licenseFileId,omitempty"`
+	CloudInitFileID     *string                     `json:"cloudInitFileId,omitempty"`
 	VirtualDeviceName   *string                     `json:"virtualDeviceName,omitempty"`
 	Notifications       []string                    `json:"notifications,omitempty"`
 	HostNamePrefix      *string                     `json:"hostNamePrefix,omitempty"`

--- a/internal/api/file.go
+++ b/internal/api/file.go
@@ -1,0 +1,6 @@
+package api
+
+//FileUploadResponse describes response to file upload request
+type FileUploadResponse struct {
+	FileUUID *string `json:"fileUuid,omitempty"`
+}

--- a/rest_device.go
+++ b/rest_device.go
@@ -364,6 +364,7 @@ func createDeviceRequest(device Device) api.DeviceRequest {
 	}
 	req.LicenseToken = device.LicenseToken
 	req.LicenseFileID = device.LicenseFileID
+	req.CloudInitFileID = device.CloudInitFileID
 	req.PackageCode = device.PackageCode
 	req.VirtualDeviceName = device.Name
 	req.Notifications = device.Notifications
@@ -397,6 +398,7 @@ func createRedundantDeviceRequest(primary Device, secondary Device) api.DeviceRe
 	secReq.MetroCode = secondary.MetroCode
 	secReq.LicenseToken = secondary.LicenseToken
 	secReq.LicenseFileID = secondary.LicenseFileID
+	secReq.CloudInitFileID = secondary.CloudInitFileID
 	secReq.VirtualDeviceName = secondary.Name
 	secReq.Notifications = secondary.Notifications
 	secReq.HostNamePrefix = secondary.HostName
@@ -421,7 +423,7 @@ func (c RestClient) replaceDeviceACLTemplate(uuid string, wanAclTemplateUuid *st
 		MgmtAclTemplateUUID: mgmtAclTemplateUuid,
 	}
 	req := c.R().SetBody(reqBody)
-	if err := c.Execute(req, http.MethodPost, path); err != nil {
+	if err := c.Execute(req, http.MethodPut, path); err != nil {
 		return err
 	}
 	return nil

--- a/rest_device.go
+++ b/rest_device.go
@@ -423,7 +423,7 @@ func (c RestClient) replaceDeviceACLTemplate(uuid string, wanAclTemplateUuid *st
 		MgmtAclTemplateUUID: mgmtAclTemplateUuid,
 	}
 	req := c.R().SetBody(reqBody)
-	if err := c.Execute(req, http.MethodPut, path); err != nil {
+	if err := c.Execute(req, http.MethodPatch, path); err != nil {
 		return err
 	}
 	return nil

--- a/rest_device_test.go
+++ b/rest_device_test.go
@@ -308,7 +308,7 @@ func TestUpdateDeviceACLTemplate(t *testing.T) {
 	testHc := &http.Client{}
 	req := api.DeviceACLTemplateRequest{}
 	httpmock.ActivateNonDefault(testHc)
-	httpmock.RegisterResponder("PUT", fmt.Sprintf("%s/ne/v1/devices/%s/acl", baseURL, devID),
+	httpmock.RegisterResponder("PATCH", fmt.Sprintf("%s/ne/v1/devices/%s/acl", baseURL, devID),
 		func(r *http.Request) (*http.Response, error) {
 			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 				return httpmock.NewStringResponse(400, ""), nil

--- a/rest_device_test.go
+++ b/rest_device_test.go
@@ -21,6 +21,7 @@ var testDevice = Device{
 	IsBYOL:              Bool(true),
 	LicenseToken:        String("somelicensetokenaaaaazzzzz"),
 	LicenseFileID:       String("8d180057-8309-4c59-b645-f630f010ad43"),
+	CloudInitFileID:     String("9318885d-4b8c-48a5-9aa4-24387834ebae"),
 	MetroCode:           String("SV"),
 	Notifications:       []string{"test1@example.com", "test2@example.com"},
 	PackageCode:         String("VM100"),
@@ -307,7 +308,7 @@ func TestUpdateDeviceACLTemplate(t *testing.T) {
 	testHc := &http.Client{}
 	req := api.DeviceACLTemplateRequest{}
 	httpmock.ActivateNonDefault(testHc)
-	httpmock.RegisterResponder("POST", fmt.Sprintf("%s/ne/v1/devices/%s/acl", baseURL, devID),
+	httpmock.RegisterResponder("PUT", fmt.Sprintf("%s/ne/v1/devices/%s/acl", baseURL, devID),
 		func(r *http.Request) (*http.Response, error) {
 			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 				return httpmock.NewStringResponse(400, ""), nil
@@ -444,6 +445,7 @@ func verifyDeviceRequest(t *testing.T, device Device, req api.DeviceRequest) {
 	}
 	assert.Equal(t, device.LicenseToken, req.LicenseToken, "LicenseToken matches")
 	assert.Equal(t, device.LicenseFileID, req.LicenseFileID, "LicenseFileID matches")
+	assert.Equal(t, device.CloudInitFileID, req.CloudInitFileID, "CloudInitFileID matches")
 	assert.Equal(t, device.PackageCode, req.PackageCode, "PackageCode matches")
 	assert.Equal(t, device.Name, req.VirtualDeviceName, "Name matches")
 	assert.ElementsMatch(t, device.Notifications, req.Notifications, "Notifications matches")

--- a/rest_file.go
+++ b/rest_file.go
@@ -1,0 +1,36 @@
+package ne
+
+import (
+	"github.com/equinix/ne-go/internal/api"
+	"io"
+	"net/http"
+)
+
+const (
+	//ProcessTypeLicense indicates file type where customer is uploading a license file
+	ProcessTypeLicense = "LICENSE"
+
+	//ProcessTypeCloudInit indicates file type where customer is uploading a cloud_init file
+	ProcessTypeCloudInit = "CLOUD_INIT"
+)
+
+//UploadFile performs multipart upload of a cloud_init/license file from a given reader interface
+//along with provided data. Uploaded file identifier is returned on success.
+func (c RestClient) UploadFile(metroCode, deviceTypeCode, processType, deviceManagementMode, licenseMode, fileName string, reader io.Reader) (*string, error) {
+	path := "/ne/v1/files"
+	respBody := api.FileUploadResponse{}
+	req := c.R().
+		SetFileReader("file", fileName, reader).
+		SetFormData(map[string]string{
+			"metroCode":            metroCode,
+			"deviceTypeCode":       deviceTypeCode,
+			"processType":          processType,
+			"licenseType":          licenseMode,
+			"deviceManagementType": deviceManagementMode,
+		}).
+		SetResult(&respBody)
+	if err := c.Execute(req, http.MethodPost, path); err != nil {
+		return nil, err
+	}
+	return respBody.FileUUID, nil
+}

--- a/rest_file_test.go
+++ b/rest_file_test.go
@@ -1,0 +1,57 @@
+package ne
+
+import (
+	"context"
+	"fmt"
+	"github.com/equinix/ne-go/internal/api"
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"os"
+	"testing"
+)
+
+func TestUploadFile(t *testing.T) {
+	//given
+	cloudInitFile, err := os.Open("test-fixtures/test_cloud_init_file.txt")
+	if err != nil {
+		assert.Fail(t, "Cannot read test cloud_init file")
+	}
+	defer cloudInitFile.Close()
+	resp := api.FileUploadResponse{}
+	if err := readJSONData("./test-fixtures/ne_file_upload_resp.json", &resp); err != nil {
+		assert.Fail(t, "Cannot read test response")
+	}
+	testHc := &http.Client{}
+	metroCode := "SV"
+	deviceTypeCode := "AVIATRIX_EDGE"
+	processType := ProcessTypeCloudInit
+	managementMode := DeviceManagementTypeSelf
+	licenseMode := DeviceLicenseModeBYOL
+	fileName := "AVIATRIX.txt"
+	httpmock.ActivateNonDefault(testHc)
+	httpmock.RegisterResponder("POST", fmt.Sprintf("%s/ne/v1/files", baseURL),
+		func(r *http.Request) (*http.Response, error) {
+			if err := r.ParseMultipartForm(32 << 20); err != nil {
+				return httpmock.NewStringResponse(400, err.Error()), nil
+			}
+			assert.Equal(t, metroCode, r.MultipartForm.Value["metroCode"][0], "Form metroCode matches")
+			assert.Equal(t, deviceTypeCode, r.MultipartForm.Value["deviceTypeCode"][0], "Form deviceTypeCode matches")
+			assert.Equal(t, processType, r.MultipartForm.Value["processType"][0], "Form processType matches")
+			assert.Equal(t, managementMode, r.MultipartForm.Value["deviceManagementType"][0], "Form deviceManagementType matches")
+			assert.Equal(t, licenseMode, r.MultipartForm.Value["licenseType"][0], "Form licenseType matches")
+			assert.NotNil(t, r.MultipartForm.File["file"])
+			resp, _ := httpmock.NewJsonResponse(201, resp)
+			return resp, nil
+		},
+	)
+	defer httpmock.DeactivateAndReset()
+
+	//when
+	c := NewClient(context.Background(), baseURL, testHc)
+	id, err := c.UploadFile(metroCode, deviceTypeCode, processType, managementMode, licenseMode, fileName, cloudInitFile)
+
+	//then
+	assert.Nil(t, err, "Error is not returned")
+	assert.Equal(t, resp.FileUUID, id, "File identifier matches")
+}

--- a/test-fixtures/ne_file_upload_resp.json
+++ b/test-fixtures/ne_file_upload_resp.json
@@ -1,0 +1,3 @@
+{
+  "fileUuid": "3cad85ae-6803-437b-8e1a-dd206d71bff8"
+}

--- a/test-fixtures/test_cloud_init_file.txt
+++ b/test-fixtures/test_cloud_init_file.txt
@@ -1,0 +1,5 @@
+Q598413432 kekefv kwekek bbk8ea kkz9yb opol3l Rr67vf
+           krqwev mmnf5j ccfg4f ll5ksx io4krw 99ecmr
+           l4dm2d miuraa l4l4l5 442ddd kk48e8 je2344
+           u5m4m4 oolrl5 935m4j faeje3 awrv2k i83m3e
+           kk4p


### PR DESCRIPTION
In Dec release, we onboarded Aviatrix as our new vendor. It requires the customer to upload cloud init file and do some basic file processing from the file. Hence, new file upload API is introduced to handle such file processing and this new file type. Also, in the device creation flow, new field cloudInitFileId is introduced for the given file. Noted that this new file API can also handle other file type. The processType field is used to identify different file types. More details can be found in the public API documentation.

reference: [NE API Documentation](https://developer.equinix.com/docs?page=/dev-docs/ne/overview)