### PR TITLE
NFV-23345: introduce get file by uuid API for new file resource and add more test cases

### DIFF
--- a/client.go
+++ b/client.go
@@ -127,6 +127,7 @@ type Client interface {
 
 	UploadLicenseFile(metroCode, deviceTypeCode, deviceManagementMode, licenseMode, fileName string, reader io.Reader) (*string, error)
 	UploadFile(metroCode, deviceTypeCode, processType, deviceManagementMode, licenseMode, fileName string, reader io.Reader) (*string, error)
+	GetFile(uuid string) (*File, error)
 
 	GetDeviceLinkGroups() ([]DeviceLinkGroup, error)
 	GetDeviceLinkGroup(uuid string) (*DeviceLinkGroup, error)
@@ -457,4 +458,14 @@ type ClusterNode struct { // Deprecated: Use ClusterNodeDetail instead
 	Node                *int
 	AdminPassword       *string
 	VendorConfiguration map[string]string
+}
+
+//File describes Network Edge uploaded file
+type File struct {
+	UUID           *string
+	FileName       *string
+	MetroCode      *string
+	DeviceTypeCode *string
+	ProcessType    *string
+	Status         *string
 }

--- a/internal/api/file.go
+++ b/internal/api/file.go
@@ -1,5 +1,15 @@
 package api
 
+//File describes Network Edge uploaded file
+type File struct {
+	UUID           *string `json:"uuid,omitempty"`
+	FileName       *string `json:"fileName,omitempty"`
+	MetroCode      *string `json:"metroCode,omitempty"`
+	DeviceTypeCode *string `json:"deviceTypeCode,omitempty"`
+	ProcessType    *string `json:"processType,omitempty"`
+	Status         *string `json:"status,omitempty"`
+}
+
 //FileUploadResponse describes response to file upload request
 type FileUploadResponse struct {
 	FileUUID *string `json:"fileUuid,omitempty"`

--- a/rest_file.go
+++ b/rest_file.go
@@ -4,6 +4,7 @@ import (
 	"github.com/equinix/ne-go/internal/api"
 	"io"
 	"net/http"
+	"net/url"
 )
 
 const (
@@ -33,4 +34,27 @@ func (c RestClient) UploadFile(metroCode, deviceTypeCode, processType, deviceMan
 		return nil, err
 	}
 	return respBody.FileUUID, nil
+}
+
+//GetFile retrieves file metadata with a given UUID
+func (c RestClient) GetFile(uuid string) (*File, error) {
+	path := "/ne/v1/files/" + url.PathEscape(uuid)
+	respBody := api.File{}
+	req := c.R().SetResult(&respBody)
+	if err := c.Execute(req, http.MethodGet, path); err != nil {
+		return nil, err
+	}
+	file := mapFileAPIToDomain(respBody)
+	return &file, nil
+}
+
+func mapFileAPIToDomain(apiFile api.File) File {
+	return File{
+		UUID:           apiFile.UUID,
+		FileName:       apiFile.FileName,
+		MetroCode:      apiFile.MetroCode,
+		DeviceTypeCode: apiFile.DeviceTypeCode,
+		ProcessType:    apiFile.ProcessType,
+		Status:         apiFile.Status,
+	}
 }

--- a/rest_file_test.go
+++ b/rest_file_test.go
@@ -55,3 +55,32 @@ func TestUploadFile(t *testing.T) {
 	assert.Nil(t, err, "Error is not returned")
 	assert.Equal(t, resp.FileUUID, id, "File identifier matches")
 }
+
+func TestGetFile(t *testing.T) {
+	//given
+	resp := api.File{}
+	if err := readJSONData("./test-fixtures/ne_file_get_resp.json", &resp); err != nil {
+		assert.Fail(t, "Cannot read test response")
+	}
+	fileID := "26728391-2706-4135-87f2-19822bcb4721"
+	testHc := setupMockedClient("GET", fmt.Sprintf("%s/ne/v1/files/%s", baseURL, fileID), 200, resp)
+	defer httpmock.DeactivateAndReset()
+
+	//when
+	c := NewClient(context.Background(), baseURL, testHc)
+	file, err := c.GetFile(fileID)
+
+	//then
+	assert.NotNil(t, file, "Returned file is not nil")
+	assert.Nil(t, err, "Error is not returned")
+	verifyFile(t, resp, *file)
+}
+
+func verifyFile(t *testing.T, apiFile api.File, file File) {
+	assert.Equal(t, apiFile.UUID, file.UUID, "UUID matches")
+	assert.Equal(t, apiFile.FileName, file.FileName, "FileName matches")
+	assert.Equal(t, apiFile.MetroCode, file.MetroCode, "MetroCode matches")
+	assert.Equal(t, apiFile.DeviceTypeCode, file.DeviceTypeCode, "DeviceTypeCode matches")
+	assert.Equal(t, apiFile.ProcessType, file.ProcessType, "ProcessType matches")
+	assert.Equal(t, apiFile.Status, file.Status, "Status matches")
+}

--- a/test-fixtures/ne_file_get_resp.json
+++ b/test-fixtures/ne_file_get_resp.json
@@ -1,0 +1,8 @@
+{
+  "uuid": "26728391-2706-4135-87f2-19822bcb4721",
+  "fileName": "test",
+  "metroCode": "SV",
+  "deviceTypeCode": "AVIATRIX_EDGE",
+  "processType": "CLOUD_INIT",
+  "status": "UPLOADED"
+}


### PR DESCRIPTION
In Dec release, we onboarded Aviatrix as our new vendor. It requires the customer to upload cloud init file and do some basic file processing from the file. Hence, new file upload API is introduced to handle such file processing and this new file type. Also, in the device creation flow, new field cloudInitFileId is introduced for the given file. Noted that this new file API can also handle other file type. The processType field is used to identify different file types. More details can be found in the public API documentation.

As discussed in https://github.com/equinix/terraform-provider-equinix/pull/287, we decide to introduce a file resource to handle a general file uploading procedure. A new GET api is required for this resource. This GET api will return some metadata after the file is uploaded. The POST api is introduced in https://github.com/equinix/ne-go/pull/18.

reference: [NE API Documentation](https://developer.equinix.com/docs?page=/dev-docs/ne/overview)
