### PR TITLE
NFV-23888: introduce keyType field for public key POST and GET APIs

### DIFF
--- a/client.go
+++ b/client.go
@@ -352,6 +352,7 @@ type SSHPublicKey struct {
 	UUID  *string
 	Name  *string
 	Value *string
+	Type  *string
 }
 
 //ACLTemplate describes Network Edge device ACL template

--- a/internal/api/sshkey.go
+++ b/internal/api/sshkey.go
@@ -5,4 +5,5 @@ type SSHPublicKey struct {
 	UUID     *string `json:"uuid,omitempty"`
 	KeyName  *string `json:"keyName,omitempty"`
 	KeyValue *string `json:"keyValue,omitempty"`
+	KeyType  *string `json:"keyType,omitempty"`
 }

--- a/rest_sshkey.go
+++ b/rest_sshkey.go
@@ -68,6 +68,7 @@ func mapSSHPublicKeyAPIToDomain(apiKey api.SSHPublicKey) SSHPublicKey {
 		UUID:  apiKey.UUID,
 		Name:  apiKey.KeyName,
 		Value: apiKey.KeyValue,
+		Type:  apiKey.KeyType,
 	}
 }
 
@@ -76,5 +77,6 @@ func mapSSHPublicKeyDomainToAPI(key SSHPublicKey) api.SSHPublicKey {
 		UUID:     key.UUID,
 		KeyName:  key.Name,
 		KeyValue: key.Value,
+		KeyType:  key.Type,
 	}
 }

--- a/rest_sshkey_test.go
+++ b/rest_sshkey_test.go
@@ -15,6 +15,7 @@ import (
 var testSSHPublicKey = SSHPublicKey{
 	Name:  String("testKey"),
 	Value: String("keyyyyyyyyyyyyyyyyyyyyyyyyy"),
+	Type:  String("RSA"),
 }
 
 func TestGetSSHPublicKeys(t *testing.T) {
@@ -109,4 +110,5 @@ func verifySSHPublicKey(t *testing.T, apiKey api.SSHPublicKey, key SSHPublicKey)
 	assert.Equal(t, apiKey.UUID, key.UUID, "UUID matches")
 	assert.Equal(t, apiKey.KeyName, key.Name, "Name matches")
 	assert.Equal(t, apiKey.KeyValue, key.Value, "Value matches")
+	assert.Equal(t, apiKey.KeyType, key.Type, "Type matches")
 }

--- a/test-fixtures/ne_sshpubkey_get.json
+++ b/test-fixtures/ne_sshpubkey_get.json
@@ -2,5 +2,6 @@
     "uuid": "71c35a94-edf7-4537-9b96-57cdfeaf7a2f",
     "keyName": "mik-test",
     "keyValue": "keyyyyyyyyyyyyyyyyyyyyyyyyy",
+    "keyType": "RSA",
     "custOrgId": 86108
 }

--- a/test-fixtures/ne_sshpubkeys_get.json
+++ b/test-fixtures/ne_sshpubkeys_get.json
@@ -3,18 +3,21 @@
         "uuid": "288e87ff-9ad3-4f50-aab8-58a0b7b1bdd2",
         "keyName": "keyN828A",
         "keyValue": "keyyyyyyyyyyyyyyyyyyyyyyyyy",
+        "keyType": "RSA",
         "custOrgId": 86108
     },
     {
         "uuid": "50d64c3c-e2e6-48b8-95bb-cd2cbc4df34a",
         "keyName": "keyDqACq",
         "keyValue": "keyyyyyyyyyyyyyyyyyyyyyyyyy",
+        "keyType": "RSA",
         "custOrgId": 86108
     },
     {
         "uuid": "d74a548c-623d-4cd2-b4ab-cb6f7cb5e443",
         "keyName": "keyTyVDJ",
         "keyValue": "keyyyyyyyyyyyyyyyyyyyyyyyyy",
+        "keyType": "DSA",
         "custOrgId": 86108
     }
 ]


### PR DESCRIPTION
In Feb release, we onboarded Arista router in our market place, but only DSA public key is accepted for this vendor. To accommodate this, a new field keyType is introduced when creating a new public key. To support backward compatibility, this new field will be marked as optional and the default value would be RSA in this case. All existing public key that we have in production is RSA key and we migrate those keys to be RSA. 
More details could be found in our API documentation. 
reference: https://developer.equinix.com/docs?page=/dev-docs/ne/overview